### PR TITLE
Opt into Node 24 for GitHub Actions

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -3,6 +3,9 @@ name: Docker Image CI
 on:
   push
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
 
   push_to_registry:


### PR DESCRIPTION
Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` to `.github/workflows/docker-image.yml` to opt into testing Node 24 ahead of the deprecation of Node 20 on GitHub Actions runners, as per the GitHub changelog: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/.

---
*PR created automatically by Jules for task [2517771398023123213](https://jules.google.com/task/2517771398023123213) started by @curfew-marathon*