### PR TITLE
ci: Add Dependabot configuration for pip

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
This PR adds Dependabot configuration for the `pip` package ecosystem to automate dependency updates. 

Changes include:
- Creating `.github/dependabot.yml`.
- Configuring Dependabot to monitor `pip` dependencies at the repository root `/`.
- Setting the update schedule to `weekly`.

---
*PR created automatically by Jules for task [2387908208625986470](https://jules.google.com/task/2387908208625986470) started by @curfew-marathon*