### PR TITLE
🧪 Add test for adjust_extensions function in exifhelper

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: run tests
         run: |
+          pip install -r requirements.txt
           pip install pytest
           export PYTHONPATH=$PYTHONPATH:$(pwd)/src
           pytest tests

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -1,0 +1,24 @@
+from unittest.mock import patch
+import pytest
+
+from src.importrr.exifhelper import adjust_extensions
+
+@patch('src.importrr.exifhelper.run_exiftool')
+def test_adjust_extensions_params(mock_run_exiftool):
+    import_dir = '/test/import/dir'
+    root_dir = '/test/root/dir'
+
+    adjust_extensions(import_dir, root_dir)
+
+    expected_params = [
+        '-filename<%f.$fileTypeExtension',
+        '-ext', 'GIF',
+        '-ext', 'JPG',
+        '-ext', 'PNG',
+        '-ext', '3GP',
+        '-ext', 'MOV',
+        '-ext', 'MP4',
+        import_dir
+    ]
+
+    mock_run_exiftool.assert_called_once_with(root_dir, expected_params)


### PR DESCRIPTION
🎯 **What:** A test for `adjust_extensions` in `src/importrr/exifhelper.py` was missing. The issue requested to mock `run_exiftool` and verify the exact params list, specifically that the right extensions are present.
📊 **Coverage:** The new test ensures that `adjust_extensions` builds the correct ExifTool arguments for standardising extensions for GIF, JPG, PNG, 3GP, MOV, and MP4.
✨ **Result:** Test coverage and reliability of the ExifTool parameter generation logic has been improved.

---
*PR created automatically by Jules for task [11489900142586310368](https://jules.google.com/task/11489900142586310368) started by @curfew-marathon*