### PR TITLE
🧹 Code health improvement: Remove unused `os` import

### DIFF
--- a/src/launch.py
+++ b/src/launch.py
@@ -1,7 +1,6 @@
 import logging
 import signal
 import sys
-import os
 from datetime import datetime
 
 from apscheduler.schedulers.blocking import BlockingScheduler


### PR DESCRIPTION
🎯 **What:** Removed unused `os` import from `src/launch.py`.
💡 **Why:** The `os` module was imported but not used, causing static analysis tools to flag it as dead code. Removing it improves the maintainability and readability of the codebase.
✅ **Verification:** Verified by checking `grep -rn "os" src/launch.py` to confirm the only occurrence was the import statement itself. Ran `pytest` tests which passed correctly. Requested a code review which concluded this was correct.
✨ **Result:** Cleaned up code that's easier to maintain without changing behavior.

---
*PR created automatically by Jules for task [11918229610599317808](https://jules.google.com/task/11918229610599317808) started by @curfew-marathon*