### PR TITLE
🧪 test: improve test coverage and edge cases for config get_serial

### DIFF
--- a/tests/test_config_methods.py
+++ b/tests/test_config_methods.py
@@ -6,7 +6,11 @@ def dummy_config():
     config = Config.__new__(Config)
     config.album_root = '/album'
     config.archive_root = '/archive'
-    config.data = [{'archive': '/archive/1', 'serial': 'S123'}]
+    config.data = [
+        {'archive': '/archive/1', 'serial': 'S123'},
+        {'archive': '/archive/2', 'serial': None},
+        {'archive': '/archive/3'},
+    ]
     return config
 
 def test_get_album(dummy_config):
@@ -16,11 +20,16 @@ def test_get_archive(dummy_config):
     assert dummy_config.get_archive() == '/archive'
 
 def test_get_data(dummy_config):
-    assert len(dummy_config.get_data()) == 1
+    assert len(dummy_config.get_data()) == 3
 
-def test_get_serial_found(dummy_config):
-    assert dummy_config.get_serial('/archive/1') == 'S123'
+@pytest.mark.parametrize("archive_path, expected_serial", [
+    ('/archive/1', 'S123'),
+    ('/archive/2', None),
+    ('/archive/3', None),
+])
+def test_get_serial_found(dummy_config, archive_path, expected_serial):
+    assert dummy_config.get_serial(archive_path) == expected_serial
 
 def test_get_serial_not_found(dummy_config):
-    with pytest.raises(KeyError):
+    with pytest.raises(KeyError, match="No serial for /not_found"):
         dummy_config.get_serial('/not_found')


### PR DESCRIPTION
🎯 **What:** The testing gap in `Config.get_serial` (which missed covering `serial` missing edge cases and explicit error messages) has been addressed by improving tests in `tests/test_config_methods.py`.

📊 **Coverage:** Test coverage for `get_serial` has been improved by utilizing `@pytest.mark.parametrize` to check multiple edge cases. Scenarios now tested include when the archive is present with a valid serial, when the archive is present but its serial is explicitly `None`, and when the archive is present but its `serial` key is omitted entirely. Tests also explicitly match the `KeyError` message output when the archive cannot be found.

✨ **Result:** Test coverage for `src/importrr/config.py` has been significantly increased and robustness has been improved by efficiently handling dictionary `None` returns and explicit missing `KeyError` messages.

---
*PR created automatically by Jules for task [6096191821896755408](https://jules.google.com/task/6096191821896755408) started by @curfew-marathon*