### PR TITLE
🧪 Add test for missing global config section

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,14 @@
 import unittest
+from unittest.mock import patch
 from src.importrr.config import Config
 
 class TestConfig(unittest.TestCase):
     def test_no_config_file(self):
         with self.assertRaises(FileNotFoundError):
+            Config()
+
+    @patch('src.importrr.config.os.path.exists', return_value=True)
+    @patch('src.importrr.config.ConfigParser.sections', return_value=[])
+    def test_missing_global_section(self, mock_sections, mock_exists):
+        with self.assertRaisesRegex(ValueError, "Missing required 'global' section in configuration"):
             Config()


### PR DESCRIPTION
🎯 **What:** The testing gap addressed was testing the condition where a configuration file exists, but it doesn't contain a `global` section.
📊 **Coverage:** The scenario where `Config()` raises a `ValueError` for a missing `global` section is now tested using mocked `os.path.exists` and `ConfigParser.sections`.
✨ **Result:** Test coverage for `src/importrr/config.py` initialization edge cases is improved.

---
*PR created automatically by Jules for task [8408568313521242589](https://jules.google.com/task/8408568313521242589) started by @curfew-marathon*