### PR TITLE
🧪 test: backfill_video_tag parameter formatting

### DIFF
--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -22,3 +22,27 @@ def test_adjust_extensions_params(mock_run_exiftool):
     ]
 
     mock_run_exiftool.assert_called_once_with(root_dir, expected_params)
+
+
+@patch('src.importrr.exifhelper.run_exiftool')
+@pytest.mark.parametrize("tag", ["CreationDate", "CreateDate"])
+def test_backfill_video_tag_params(mock_run_exiftool, tag):
+    import_dir = '/test/import/dir'
+    root_dir = '/test/root/dir'
+
+    from src.importrr.exifhelper import backfill_video_tag
+    backfill_video_tag(import_dir, root_dir, tag)
+
+    expected_params = [
+        '-overwrite_original',
+        '-datetimeoriginal<' + tag,
+        '-time:all<$' + tag,
+        '-if',
+        'not $datetimeoriginal',
+        '-ext', '3GP',
+        '-ext', 'MOV',
+        '-ext', 'MP4',
+        import_dir
+    ]
+
+    mock_run_exiftool.assert_called_once_with(root_dir, expected_params)


### PR DESCRIPTION
🎯 **What:** The testing gap addressed
Tested the `backfill_video_tag` method in `exifhelper.py` which had no tests verifying the parameter formatting behavior when supplying different tags.

📊 **Coverage:** What scenarios are now tested
The unit test mocks the `run_exiftool` method and verifies that the formatted `params` array has the `tag` correctly interpolated into both `-datetimeoriginal<TAG` and `-time:all<$TAG` (e.g. `CreationDate`, `CreateDate`) and checks the other default flags.

✨ **Result:** The improvement in test coverage
Ensures `backfill_video_tag` functionality executes deterministically and prevents regression if logic inside the parameter building function is altered.

---
*PR created automatically by Jules for task [4390090057295422717](https://jules.google.com/task/4390090057295422717) started by @curfew-marathon*