### PR TITLE
🧹 Rename 'dict' variable in config.py to avoid shadowing built-in type

### DIFF
--- a/src/importrr/config.py
+++ b/src/importrr/config.py
@@ -75,7 +75,7 @@ class Config:
         return self.data
 
     def get_serial(self, d):
-        for dict in self.data:
-            if d == dict.get('archive'):
-                return dict.get('serial')
+        for entry in self.data:
+            if d == entry.get('archive'):
+                return entry.get('serial')
         raise KeyError("No serial for " + d)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,7 +1,38 @@
 import unittest
+from unittest.mock import patch
+import os
+import tempfile
 from src.importrr.config import Config
 
 class TestConfig(unittest.TestCase):
     def test_no_config_file(self):
         with self.assertRaises(FileNotFoundError):
             Config()
+
+    def test_get_serial(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write("[global]\nalbum_dir = /albums\narchive_dir = /archives\n")
+            f.write("[vacation]\nimport_dir = /import1\nserial = 12345\n")
+            temp_name = f.name
+
+        try:
+            with patch('src.importrr.config.CANDIDATES', [temp_name]):
+                config = Config()
+                archive_path = os.path.join("/archives", "vacation")
+                self.assertEqual(config.get_serial(archive_path), "12345")
+        finally:
+            os.remove(temp_name)
+
+    def test_get_serial_not_found(self):
+        with tempfile.NamedTemporaryFile(mode='w', suffix='.ini', delete=False) as f:
+            f.write("[global]\nalbum_dir = /albums\narchive_dir = /archives\n")
+            f.write("[vacation]\nimport_dir = /import1\nserial = 12345\n")
+            temp_name = f.name
+
+        try:
+            with patch('src.importrr.config.CANDIDATES', [temp_name]):
+                config = Config()
+                with self.assertRaises(KeyError):
+                    config.get_serial("/non/existent")
+        finally:
+            os.remove(temp_name)


### PR DESCRIPTION
🎯 **What:** Renamed the 'dict' variable in `src/importrr/config.py:78` to `entry`.
💡 **Why:** Renaming 'dict' to 'entry' avoids shadowing the built-in dictionary type in Python, which is a best practice to prevent potential bugs and improve code readability.
✅ **Verification:**
  - Added new test cases `test_get_serial` and `test_get_serial_not_found` to `tests/test_config.py`.
  - Ran `python3 -m unittest discover -s tests` and confirmed that all tests pass.
  - Verified the change manually by inspecting the source file.
✨ **Result:** The code no longer shadows a built-in Python type, enhancing its maintainability.

---
*PR created automatically by Jules for task [12475988313296642880](https://jules.google.com/task/12475988313296642880) started by @curfew-marathon*