### PR TITLE
🧹 [Code Health] Extract common logic in adjust_screenshots

### DIFF
--- a/src/importrr/exifhelper.py
+++ b/src/importrr/exifhelper.py
@@ -52,36 +52,31 @@ def adjust_extensions(import_dir, root_dir):
 def adjust_screenshots(import_dir, root_dir):
     logger.info("Backfilling EXIF dates for screenshots and images")
     logger.debug(f"Processing files in: {import_dir}")
+
+    common_params = [
+        "-if",
+        "not $datetimeoriginal",
+        "-ext",
+        "GIF",
+        "-ext",
+        "JPG",
+        "-ext",
+        "PNG",
+        import_dir,
+    ]
+
     # if there is any date in the metadata then add it in
     params = [
         "-overwrite_original",
         "-EXIF:DateTimeOriginal<PNG:CreateDate",
         "-XMP:DateCreated<PNG:CreateDate",
-        "-if",
-        "not $datetimeoriginal",
-        "-ext",
-        "GIF",
-        "-ext",
-        "JPG",
-        "-ext",
-        "PNG",
-        import_dir,
-    ]
+    ] + common_params
     run_exiftool(root_dir, params)
 
     params = [
         "-overwrite_original",
         "-EXIF:DateTimeOriginal<XMP:DateCreated",
-        "-if",
-        "not $datetimeoriginal",
-        "-ext",
-        "GIF",
-        "-ext",
-        "JPG",
-        "-ext",
-        "PNG",
-        import_dir,
-    ]
+    ] + common_params
     run_exiftool(root_dir, params)
 
     # for everything that's left just use the file modify date
@@ -89,16 +84,7 @@ def adjust_screenshots(import_dir, root_dir):
         "-overwrite_original",
         "-EXIF:DateTimeOriginal<FileModifyDate",
         "-XMP:DateCreated<FileModifyDate",
-        "-if",
-        "not $datetimeoriginal",
-        "-ext",
-        "GIF",
-        "-ext",
-        "JPG",
-        "-ext",
-        "PNG",
-        import_dir,
-    ]
+    ] + common_params
     run_exiftool(root_dir, params)
 
 

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -58,6 +58,7 @@ def test_backfill_video_tag_params(mock_run_exiftool, tag):
 
     mock_run_exiftool.assert_called_once_with(root_dir, expected_params)
 
+
 @patch("src.importrr.exifhelper.run_exiftool")
 def test_adjust_screenshots_params(mock_run_exiftool):
     import_dir = "/test/import/dir"
@@ -69,46 +70,55 @@ def test_adjust_screenshots_params(mock_run_exiftool):
 
     assert mock_run_exiftool.call_count == 3
 
-    mock_run_exiftool.assert_any_call(root_dir, [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<PNG:CreateDate",
-        "-XMP:DateCreated<PNG:CreateDate",
-        "-if",
-        "not $datetimeoriginal",
-        "-ext",
-        "GIF",
-        "-ext",
-        "JPG",
-        "-ext",
-        "PNG",
-        import_dir,
-    ])
+    mock_run_exiftool.assert_any_call(
+        root_dir,
+        [
+            "-overwrite_original",
+            "-EXIF:DateTimeOriginal<PNG:CreateDate",
+            "-XMP:DateCreated<PNG:CreateDate",
+            "-if",
+            "not $datetimeoriginal",
+            "-ext",
+            "GIF",
+            "-ext",
+            "JPG",
+            "-ext",
+            "PNG",
+            import_dir,
+        ],
+    )
 
-    mock_run_exiftool.assert_any_call(root_dir, [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<XMP:DateCreated",
-        "-if",
-        "not $datetimeoriginal",
-        "-ext",
-        "GIF",
-        "-ext",
-        "JPG",
-        "-ext",
-        "PNG",
-        import_dir,
-    ])
+    mock_run_exiftool.assert_any_call(
+        root_dir,
+        [
+            "-overwrite_original",
+            "-EXIF:DateTimeOriginal<XMP:DateCreated",
+            "-if",
+            "not $datetimeoriginal",
+            "-ext",
+            "GIF",
+            "-ext",
+            "JPG",
+            "-ext",
+            "PNG",
+            import_dir,
+        ],
+    )
 
-    mock_run_exiftool.assert_any_call(root_dir, [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<FileModifyDate",
-        "-XMP:DateCreated<FileModifyDate",
-        "-if",
-        "not $datetimeoriginal",
-        "-ext",
-        "GIF",
-        "-ext",
-        "JPG",
-        "-ext",
-        "PNG",
-        import_dir,
-    ])
+    mock_run_exiftool.assert_any_call(
+        root_dir,
+        [
+            "-overwrite_original",
+            "-EXIF:DateTimeOriginal<FileModifyDate",
+            "-XMP:DateCreated<FileModifyDate",
+            "-if",
+            "not $datetimeoriginal",
+            "-ext",
+            "GIF",
+            "-ext",
+            "JPG",
+            "-ext",
+            "PNG",
+            import_dir,
+        ],
+    )

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -57,3 +57,58 @@ def test_backfill_video_tag_params(mock_run_exiftool, tag):
     ]
 
     mock_run_exiftool.assert_called_once_with(root_dir, expected_params)
+
+@patch("src.importrr.exifhelper.run_exiftool")
+def test_adjust_screenshots_params(mock_run_exiftool):
+    import_dir = "/test/import/dir"
+    root_dir = "/test/root/dir"
+
+    from src.importrr.exifhelper import adjust_screenshots
+
+    adjust_screenshots(import_dir, root_dir)
+
+    assert mock_run_exiftool.call_count == 3
+
+    mock_run_exiftool.assert_any_call(root_dir, [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<PNG:CreateDate",
+        "-XMP:DateCreated<PNG:CreateDate",
+        "-if",
+        "not $datetimeoriginal",
+        "-ext",
+        "GIF",
+        "-ext",
+        "JPG",
+        "-ext",
+        "PNG",
+        import_dir,
+    ])
+
+    mock_run_exiftool.assert_any_call(root_dir, [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<XMP:DateCreated",
+        "-if",
+        "not $datetimeoriginal",
+        "-ext",
+        "GIF",
+        "-ext",
+        "JPG",
+        "-ext",
+        "PNG",
+        import_dir,
+    ])
+
+    mock_run_exiftool.assert_any_call(root_dir, [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<FileModifyDate",
+        "-XMP:DateCreated<FileModifyDate",
+        "-if",
+        "not $datetimeoriginal",
+        "-ext",
+        "GIF",
+        "-ext",
+        "JPG",
+        "-ext",
+        "PNG",
+        import_dir,
+    ])


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Extracted duplicated ExifTool string parameters (extensions, conditions, and import directory) from three separate `run_exiftool` calls within `adjust_screenshots` into a shared `common_params` list.

💡 **Why:** How this improves maintainability
This makes the code DRY (Don't Repeat Yourself), improving readability and ensuring that any future parameter updates (like adding a new extension to ignore) only need to happen in one place.

✅ **Verification:** How you confirmed the change is safe
1. Added a unit test `test_adjust_screenshots_params` using pytest and mocks to assert that exactly the same final parameters are still being passed to `run_exiftool` correctly.
2. Verified unit tests run successfully with no regressions.

✨ **Result:** The improvement achieved
A cleaner, more maintainable `adjust_screenshots` function that preserves all original functionality and is fortified by a test case.

---
*PR created automatically by Jules for task [11708544221447437129](https://jules.google.com/task/11708544221447437129) started by @curfew-marathon*