### PR TITLE
🧹 [Code Health] Extract common logic in adjust_screenshots

### DIFF
--- a/src/importrr/exifhelper.py
+++ b/src/importrr/exifhelper.py
@@ -68,22 +68,12 @@ def adjust_screenshots(import_dir, root_dir):
     # if there is any date in the metadata then add it in
     params = [
         "-overwrite_original",
-        "-EXIF:DateTimeOriginal<PNG:CreateDate",
-        "-XMP:DateCreated<PNG:CreateDate",
-    ] + common_params
-    run_exiftool(root_dir, params)
-
-    params = [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<XMP:DateCreated",
-    ] + common_params
-    run_exiftool(root_dir, params)
-
-    # for everything that's left just use the file modify date
-    params = [
-        "-overwrite_original",
         "-EXIF:DateTimeOriginal<FileModifyDate",
         "-XMP:DateCreated<FileModifyDate",
+        "-EXIF:DateTimeOriginal<XMP:DateCreated",
+        "-XMP:DateCreated<XMP:DateCreated",
+        "-EXIF:DateTimeOriginal<PNG:CreateDate",
+        "-XMP:DateCreated<PNG:CreateDate",
     ] + common_params
     run_exiftool(root_dir, params)
 

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -68,49 +68,18 @@ def test_adjust_screenshots_params(mock_run_exiftool):
 
     adjust_screenshots(import_dir, root_dir)
 
-    assert mock_run_exiftool.call_count == 3
+    assert mock_run_exiftool.call_count == 1
 
-    mock_run_exiftool.assert_any_call(
-        root_dir,
-        [
-            "-overwrite_original",
-            "-EXIF:DateTimeOriginal<PNG:CreateDate",
-            "-XMP:DateCreated<PNG:CreateDate",
-            "-if",
-            "not $datetimeoriginal",
-            "-ext",
-            "GIF",
-            "-ext",
-            "JPG",
-            "-ext",
-            "PNG",
-            import_dir,
-        ],
-    )
-
-    mock_run_exiftool.assert_any_call(
-        root_dir,
-        [
-            "-overwrite_original",
-            "-EXIF:DateTimeOriginal<XMP:DateCreated",
-            "-if",
-            "not $datetimeoriginal",
-            "-ext",
-            "GIF",
-            "-ext",
-            "JPG",
-            "-ext",
-            "PNG",
-            import_dir,
-        ],
-    )
-
-    mock_run_exiftool.assert_any_call(
+    mock_run_exiftool.assert_called_once_with(
         root_dir,
         [
             "-overwrite_original",
             "-EXIF:DateTimeOriginal<FileModifyDate",
             "-XMP:DateCreated<FileModifyDate",
+            "-EXIF:DateTimeOriginal<XMP:DateCreated",
+            "-XMP:DateCreated<XMP:DateCreated",
+            "-EXIF:DateTimeOriginal<PNG:CreateDate",
+            "-XMP:DateCreated<PNG:CreateDate",
             "-if",
             "not $datetimeoriginal",
             "-ext",


### PR DESCRIPTION
🎯 **What:** The code health issue addressed
Combined the three sequential `run_exiftool` calls in `adjust_screenshots` into a single consolidated command, while preserving tag assignment precedence logic using left-to-right parameter ordering.
  
💡 **Why:** How this improves maintainability
This reduces duplicated EXIF extraction runs, increasing the DRYness and significantly improving overall performance by reducing process spawning overhead.

✅ **Verification:** How you confirmed the change is safe
Tests updated to reflect a single run with ordered assignments. Validated no regressions using pytest execution (`pytest tests/test_exifhelper.py`).

✨ **Result:** The improvement achieved
Achieved equivalent functionality with optimized metadata processing and execution.

---
*PR created automatically by Jules for task [4055062709141571356](https://jules.google.com/task/4055062709141571356) started by @curfew-marathon*