### PR TITLE
🧹 Rename 'dict' to 'item' to avoid shadowing built-in dictionary

### DIFF
--- a/src/importrr/config.py
+++ b/src/importrr/config.py
@@ -90,7 +90,7 @@ class Config:
         return self.data
 
     def get_serial(self, d):
-        for dict in self.data:
-            if d == dict.get("archive"):
-                return dict.get("serial")
+        for item in self.data:
+            if d == item.get("archive"):
+                return item.get("serial")
         raise KeyError("No serial for " + d)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is shadowing the built-in dictionary type `dict` by using it as a variable name in `src/importrr/config.py`. The variable has been renamed to `item`.
💡 **Why:** This improves maintainability and readability by avoiding conflicts with the built-in `dict` type, which could lead to subtle bugs if `dict()` needed to be used within the loop scope.
✅ **Verification:** Ran `pytest` tests locally specifically testing the `get_serial` functionality and full test suite, verifying all tests successfully passed. The change does not affect runtime behavior.
✨ **Result:** A safer, more readable `get_serial` method that adheres to better Python naming conventions.

---
*PR created automatically by Jules for task [673090727785454965](https://jules.google.com/task/673090727785454965) started by @curfew-marathon*