### PR TITLE
🧹 fix: avoid using 'dict' as variable name in get_serial

### DIFF
--- a/src/importrr/config.py
+++ b/src/importrr/config.py
@@ -90,7 +90,7 @@ class Config:
         return self.data
 
     def get_serial(self, d):
-        for dict in self.data:
-            if d == dict.get("archive"):
-                return dict.get("serial")
+        for item in self.data:
+            if d == item.get("archive"):
+                return item.get("serial")
         raise KeyError("No serial for " + d)


### PR DESCRIPTION
🎯 **What:** The code health issue addressed is the shadowing of the built-in Python `dict` type with a loop variable named `dict` within `src/importrr/config.py` inside the `get_serial` method.

💡 **Why:** Shadowing built-ins is generally poor practice and can lead to confusing and difficult-to-trace bugs. Changing the variable name to `item` improves code clarity and maintainability.

✅ **Verification:** I ran the `pytest` suite for the codebase to confirm that the existing tests in `tests/` pass properly.

✨ **Result:** The variable name in `get_serial` is safely replaced by `item`, resolving the shadowing problem while maintaining the function's existing logic.

---
*PR created automatically by Jules for task [3805118129065446034](https://jules.google.com/task/3805118129065446034) started by @curfew-marathon*