### PR TITLE
🧪 Add test coverage for MOV to MP4 conversion success and failure scenarios

### DIFF
--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -17,3 +17,48 @@ def test_convert_input_not_exists(mock_exists, mock_transcode):
     assert result is None
     mock_transcode.assert_not_called()
     mock_exists.assert_called_once_with(os.path.join(root_dir, source_file))
+
+
+@patch("src.importrr.transcode.exifhelper.copy_tags")
+@patch("src.importrr.transcode.os.path.getsize")
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.transcode")
+def test_convert_success(mock_transcode, mock_exists, mock_getsize, mock_copy_tags):
+    mock_exists.side_effect = [True, True]  # input exists, output exists
+    mock_getsize.side_effect = [1024, 512]  # input size, output size
+
+    root_dir = "/test/root"
+    source_file = "test_video.mov"
+
+    result = convert(root_dir, source_file)
+
+    assert result == "test_video.mp4"
+    mock_transcode.assert_called_once_with(os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
+    mock_copy_tags.assert_called_once_with(root_dir, os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
+
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.transcode")
+def test_convert_output_not_created(mock_transcode, mock_exists):
+    mock_exists.side_effect = [True, False]  # input exists, output does not exist
+
+    root_dir = "/test/root"
+    source_file = "test_video.mov"
+
+    result = convert(root_dir, source_file)
+
+    assert result is None
+    mock_transcode.assert_called_once_with(os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
+
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.transcode")
+def test_convert_exception(mock_transcode, mock_exists):
+    mock_exists.return_value = True  # input exists
+    mock_transcode.side_effect = Exception("FFmpeg error")
+
+    root_dir = "/test/root"
+    source_file = "test_video.mov"
+
+    result = convert(root_dir, source_file)
+
+    assert result is None
+    mock_transcode.assert_called_once_with(os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -33,8 +33,16 @@ def test_convert_success(mock_transcode, mock_exists, mock_getsize, mock_copy_ta
     result = convert(root_dir, source_file)
 
     assert result == "test_video.mp4"
-    mock_transcode.assert_called_once_with(os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
-    mock_copy_tags.assert_called_once_with(root_dir, os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
+    mock_transcode.assert_called_once_with(
+        os.path.join(root_dir, "test_video.mov"),
+        os.path.join(root_dir, "test_video.mp4"),
+    )
+    mock_copy_tags.assert_called_once_with(
+        root_dir,
+        os.path.join(root_dir, "test_video.mov"),
+        os.path.join(root_dir, "test_video.mp4"),
+    )
+
 
 @patch("src.importrr.transcode.os.path.exists")
 @patch("src.importrr.transcode.transcode")
@@ -47,7 +55,11 @@ def test_convert_output_not_created(mock_transcode, mock_exists):
     result = convert(root_dir, source_file)
 
     assert result is None
-    mock_transcode.assert_called_once_with(os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
+    mock_transcode.assert_called_once_with(
+        os.path.join(root_dir, "test_video.mov"),
+        os.path.join(root_dir, "test_video.mp4"),
+    )
+
 
 @patch("src.importrr.transcode.os.path.exists")
 @patch("src.importrr.transcode.transcode")
@@ -61,4 +73,7 @@ def test_convert_exception(mock_transcode, mock_exists):
     result = convert(root_dir, source_file)
 
     assert result is None
-    mock_transcode.assert_called_once_with(os.path.join(root_dir, "test_video.mov"), os.path.join(root_dir, "test_video.mp4"))
+    mock_transcode.assert_called_once_with(
+        os.path.join(root_dir, "test_video.mov"),
+        os.path.join(root_dir, "test_video.mp4"),
+    )


### PR DESCRIPTION
🎯 **What:** The testing gap addressed: The test suite in `tests/test_transcode.py` lacked coverage for scenarios where MOV to MP4 conversion either completes successfully, fails to generate an output file, or encounters an exception.
📊 **Coverage:** What scenarios are now tested:
- Happy path conversion (`test_convert_success`)
- Conversion skipping execution (`test_convert_input_not_exists`) - pre-existing
- Output file not generated during transcode (`test_convert_output_not_created`)
- Exception handling when transcode fails (`test_convert_exception`)
✨ **Result:** The improvement in test coverage: The `convert` function in `src/importrr/transcode.py` now has significantly improved test coverage for edge cases, failure states, and successful conversions without relying on actual filesystem IO or ffmpeg binaries.

---
*PR created automatically by Jules for task [11256744159802542040](https://jules.google.com/task/11256744159802542040) started by @curfew-marathon*