### PR TITLE
🧹 Replace naive string slicing with os.path.splitext in transcode.py

### DIFF
--- a/src/importrr/transcode.py
+++ b/src/importrr/transcode.py
@@ -12,7 +12,7 @@ logger = logging.getLogger(__name__)
 
 def convert(root_dir, source_file):
     logger.info(f"Converting MOV to MP4: {source_file}")
-    result = source_file[:-3] + "mp4"
+    result = os.path.splitext(source_file)[0] + ".mp4"
     output_file = os.path.join(root_dir, result)
     input_file = os.path.join(root_dir, source_file)
 

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -17,3 +17,39 @@ def test_convert_input_not_exists(mock_exists, mock_transcode):
     assert result is None
     mock_transcode.assert_not_called()
     mock_exists.assert_called_once_with(os.path.join(root_dir, source_file))
+
+
+@patch("src.importrr.transcode.transcode")
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.os.path.getsize")
+@patch("src.importrr.transcode.exifhelper.copy_tags")
+def test_convert_filename_generation(
+    mock_copy_tags, mock_getsize, mock_exists, mock_transcode
+):
+    mock_exists.side_effect = [True, True]  # input exists, output exists
+    mock_getsize.return_value = 100
+
+    root_dir = "/test/root"
+    source_file = "test_video.MOV"
+
+    result = convert(root_dir, source_file)
+
+    assert result == "test_video.mp4"
+
+
+@patch("src.importrr.transcode.transcode")
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.os.path.getsize")
+@patch("src.importrr.transcode.exifhelper.copy_tags")
+def test_convert_filename_generation_long_extension(
+    mock_copy_tags, mock_getsize, mock_exists, mock_transcode
+):
+    mock_exists.side_effect = [True, True]  # input exists, output exists
+    mock_getsize.return_value = 100
+
+    root_dir = "/test/root"
+    source_file = "test_video.mpeg"
+
+    result = convert(root_dir, source_file)
+
+    assert result == "test_video.mp4"


### PR DESCRIPTION
Replaced naive string slicing with `os.path.splitext` in `src/importrr/transcode.py` to correctly handle file extensions of varying lengths. Added unit tests in `tests/test_transcode.py` to verify the improvement.

---
*PR created automatically by Jules for task [5354670196528054837](https://jules.google.com/task/5354670196528054837) started by @curfew-marathon*