### PR TITLE
🧪 Add testing for organize() in exifhelper.py

### DIFF
--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -70,6 +70,29 @@ def test_backfill_video_tag_params(mock_run_exiftool, tag):
 
 
 @patch("src.importrr.exifhelper.run_exiftool")
+def test_organize_params(mock_run_exiftool):
+    import_dir = "/test/import/dir"
+    root_dir = "/test/root/dir"
+
+    mock_run_exiftool.return_value = "file1\nfile2\nfile3"
+
+    from src.importrr.exifhelper import organize
+
+    result = organize(import_dir, root_dir)
+
+    expected_params = [
+        "-verbose",
+        '-filename<${DateTimeOriginal#;DateFmt("%Y/%m")}/$DateTimeOriginal%-c.%e',
+        "-d",
+        "%Y%m%d-%H%M%S",
+        import_dir,
+    ]
+
+    mock_run_exiftool.assert_called_once_with(root_dir, expected_params, False)
+    assert result == ["file1", "file2", "file3"]
+
+
+@patch("src.importrr.exifhelper.run_exiftool")
 def test_adjust_screenshots_params(mock_run_exiftool):
     import_dir = "/test/import/dir"
     root_dir = "/test/root/dir"


### PR DESCRIPTION
🎯 **What:** The untested `organize()` function in `src/importrr/exifhelper.py` now has unit testing.
📊 **Coverage:** Tests a typical happy path by checking if the parameters are accurately formulated and passed to `run_exiftool()`, including ensuring the `on_error` flag is correctly set to `False`. It also tests the resulting multi-line response by splitting the output from `run_exiftool` correctly.
✨ **Result:** Improved test coverage across the `exifhelper.py` operations, making sure the string splitting logic and argument passing in `organize()` are well-tested.

---
*PR created automatically by Jules for task [17840913069204465167](https://jules.google.com/task/17840913069204465167) started by @curfew-marathon*