### PR TITLE
🔒 Fix Path Traversal via Unvalidated import_dir

### DIFF
--- a/src/importrr/sort.py
+++ b/src/importrr/sort.py
@@ -148,7 +148,14 @@ class Sort:
         time_cutoff = start - 60 * TIME_CUTOFF
         prefix = datetime.fromtimestamp(time_cutoff).strftime("%Y%m%d%H%M%S")
 
-        import_dir = os.path.join(self.root_dir, import_dir)
+        abs_root_dir = os.path.abspath(self.root_dir)
+        abs_import_dir = os.path.abspath(os.path.join(abs_root_dir, import_dir))
+
+        if os.path.commonpath([abs_root_dir, abs_import_dir]) != abs_root_dir:
+            logger.error(f"Path traversal attempt detected: {import_dir}")
+            return
+
+        import_dir = abs_import_dir
         result = get_media_files(import_dir, time_cutoff)
 
         if result:

--- a/tests/test_sort_security.py
+++ b/tests/test_sort_security.py
@@ -1,0 +1,80 @@
+import os
+from unittest.mock import patch
+
+import pytest
+
+from src.importrr.sort import Sort
+
+
+@pytest.fixture
+def mock_directories(tmp_path):
+    root_dir = tmp_path / "root"
+    root_dir.mkdir()
+
+    archive_dir = tmp_path / "archive"
+    archive_dir.mkdir()
+
+    return root_dir, archive_dir
+
+
+@patch("src.importrr.sort.get_media_files")
+@patch("src.importrr.sort.make_work_dir")
+@patch("src.importrr.sort.sort_media")
+@patch("src.importrr.sort.archive.copy")
+def test_launch_valid_import_dir(mock_copy, mock_sort_media, mock_make_work_dir, mock_get_media_files, mock_directories):
+    root_dir, archive_dir = mock_directories
+    sort = Sort(str(root_dir), str(archive_dir))
+
+    # Mock return values
+    mock_get_media_files.return_value = ["test.jpg"]
+    mock_sort_media.return_value = ["test.jpg"]
+
+    # Valid relative path
+    sort.launch("images")
+
+    # Verify get_media_files is called with correct path
+    expected_path = os.path.abspath(os.path.join(str(root_dir), "images"))
+    mock_get_media_files.assert_called_once()
+    assert mock_get_media_files.call_args[0][0] == expected_path
+
+
+@patch("src.importrr.sort.get_media_files")
+@patch("src.importrr.sort.logger")
+def test_launch_path_traversal_parent(mock_logger, mock_get_media_files, mock_directories):
+    root_dir, archive_dir = mock_directories
+    sort = Sort(str(root_dir), str(archive_dir))
+
+    # Path traversing outside root via parent dir
+    sort.launch("../outside")
+
+    # Verify processing was blocked
+    mock_get_media_files.assert_not_called()
+    mock_logger.error.assert_called_once_with("Path traversal attempt detected: ../outside")
+
+
+@patch("src.importrr.sort.get_media_files")
+@patch("src.importrr.sort.logger")
+def test_launch_path_traversal_absolute(mock_logger, mock_get_media_files, mock_directories):
+    root_dir, archive_dir = mock_directories
+    sort = Sort(str(root_dir), str(archive_dir))
+
+    # Absolute path traversing outside root
+    sort.launch("/etc")
+
+    # Verify processing was blocked
+    mock_get_media_files.assert_not_called()
+    mock_logger.error.assert_called_once_with("Path traversal attempt detected: /etc")
+
+
+@patch("src.importrr.sort.get_media_files")
+@patch("src.importrr.sort.logger")
+def test_launch_path_traversal_complex(mock_logger, mock_get_media_files, mock_directories):
+    root_dir, archive_dir = mock_directories
+    sort = Sort(str(root_dir), str(archive_dir))
+
+    # Complex path traversing outside root
+    sort.launch("images/../../outside")
+
+    # Verify processing was blocked
+    mock_get_media_files.assert_not_called()
+    mock_logger.error.assert_called_once_with("Path traversal attempt detected: images/../../outside")

--- a/tests/test_sort_security.py
+++ b/tests/test_sort_security.py
@@ -21,7 +21,13 @@ def mock_directories(tmp_path):
 @patch("src.importrr.sort.make_work_dir")
 @patch("src.importrr.sort.sort_media")
 @patch("src.importrr.sort.archive.copy")
-def test_launch_valid_import_dir(mock_copy, mock_sort_media, mock_make_work_dir, mock_get_media_files, mock_directories):
+def test_launch_valid_import_dir(
+    mock_copy,
+    mock_sort_media,
+    mock_make_work_dir,
+    mock_get_media_files,
+    mock_directories,
+):
     root_dir, archive_dir = mock_directories
     sort = Sort(str(root_dir), str(archive_dir))
 
@@ -40,7 +46,9 @@ def test_launch_valid_import_dir(mock_copy, mock_sort_media, mock_make_work_dir,
 
 @patch("src.importrr.sort.get_media_files")
 @patch("src.importrr.sort.logger")
-def test_launch_path_traversal_parent(mock_logger, mock_get_media_files, mock_directories):
+def test_launch_path_traversal_parent(
+    mock_logger, mock_get_media_files, mock_directories
+):
     root_dir, archive_dir = mock_directories
     sort = Sort(str(root_dir), str(archive_dir))
 
@@ -49,12 +57,16 @@ def test_launch_path_traversal_parent(mock_logger, mock_get_media_files, mock_di
 
     # Verify processing was blocked
     mock_get_media_files.assert_not_called()
-    mock_logger.error.assert_called_once_with("Path traversal attempt detected: ../outside")
+    mock_logger.error.assert_called_once_with(
+        "Path traversal attempt detected: ../outside"
+    )
 
 
 @patch("src.importrr.sort.get_media_files")
 @patch("src.importrr.sort.logger")
-def test_launch_path_traversal_absolute(mock_logger, mock_get_media_files, mock_directories):
+def test_launch_path_traversal_absolute(
+    mock_logger, mock_get_media_files, mock_directories
+):
     root_dir, archive_dir = mock_directories
     sort = Sort(str(root_dir), str(archive_dir))
 
@@ -68,7 +80,9 @@ def test_launch_path_traversal_absolute(mock_logger, mock_get_media_files, mock_
 
 @patch("src.importrr.sort.get_media_files")
 @patch("src.importrr.sort.logger")
-def test_launch_path_traversal_complex(mock_logger, mock_get_media_files, mock_directories):
+def test_launch_path_traversal_complex(
+    mock_logger, mock_get_media_files, mock_directories
+):
     root_dir, archive_dir = mock_directories
     sort = Sort(str(root_dir), str(archive_dir))
 
@@ -77,4 +91,6 @@ def test_launch_path_traversal_complex(mock_logger, mock_get_media_files, mock_d
 
     # Verify processing was blocked
     mock_get_media_files.assert_not_called()
-    mock_logger.error.assert_called_once_with("Path traversal attempt detected: images/../../outside")
+    mock_logger.error.assert_called_once_with(
+        "Path traversal attempt detected: images/../../outside"
+    )


### PR DESCRIPTION
🎯 **What:** The vulnerability fixed
Fixed a path traversal vulnerability in `src/importrr/sort.py` inside `Sort.launch` when handling the `import_dir` variable.

⚠️ **Risk:** The potential impact if left unfixed
An attacker (or misconfiguration) could provide an `import_dir` string like `../../etc` or an absolute path such as `/var/log` to manipulate or delete sensitive files outside the expected root directory, potentially leading to a denial of service or unauthorized access.

🛡️ **Solution:** How the fix addresses the vulnerability
Replaced the insecure use of `os.path.join` with strict absolute path resolution using `os.path.abspath`. Validation is enforced using `os.path.commonpath` to ensure the final destination correctly resolves underneath `self.root_dir` without breaking out. Included unit tests in `tests/test_sort_security.py` to assert that complex, absolute, and relative traversal attempts are all robustly blocked.

---
*PR created automatically by Jules for task [3623808791303749443](https://jules.google.com/task/3623808791303749443) started by @curfew-marathon*