### PR TITLE
🧪 Add test for ExifTool error handling

### DIFF
--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -124,3 +124,42 @@ def test_adjust_screenshots_params(mock_run_exiftool):
             import_dir,
         ],
     )
+
+@patch("src.importrr.exifhelper.os.chdir")
+@patch("src.importrr.exifhelper.ExifToolHelper")
+@pytest.mark.parametrize(
+    "returncode, stdout, stderr, on_error, should_raise",
+    [
+        (2, None, None, True, False),
+        (1, " 0 image files read", "some error", True, False),
+        (1, "some normal output", None, True, True),
+        (1, " 0 image files read", None, False, True),
+    ],
+)
+def test_run_exiftool_error_handling(
+    mock_exiftool_helper,
+    mock_chdir,
+    returncode,
+    stdout,
+    stderr,
+    on_error,
+    should_raise,
+):
+    from src.importrr.exifhelper import run_exiftool
+    from exiftool.exceptions import ExifToolExecuteError
+
+    error = ExifToolExecuteError("Test error")
+    error.returncode = returncode
+    error.stdout = stdout
+    error.stderr = stderr
+
+    mock_context = mock_exiftool_helper.return_value.__enter__.return_value
+    mock_context.execute.side_effect = error
+
+    if should_raise:
+        with pytest.raises(ExifToolExecuteError):
+            run_exiftool("/test/root", ["-test"], on_error=on_error)
+    else:
+        run_exiftool("/test/root", ["-test"], on_error=on_error)
+
+    mock_chdir.assert_called_once_with("/test/root")

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -125,6 +125,7 @@ def test_adjust_screenshots_params(mock_run_exiftool):
         ],
     )
 
+
 @patch("src.importrr.exifhelper.os.chdir")
 @patch("src.importrr.exifhelper.ExifToolHelper")
 @pytest.mark.parametrize(
@@ -148,7 +149,14 @@ def test_run_exiftool_error_handling(
     from src.importrr.exifhelper import run_exiftool
     from exiftool.exceptions import ExifToolExecuteError
 
-    error = ExifToolExecuteError("Test error")
+    # To support both the local mock ExifToolExecuteError which takes any args
+    # and the real pyexiftool which expects (status, cmd_stdout, cmd_stderr, params),
+    # we instantiate with multiple args or handle gracefully.
+    try:
+        error = ExifToolExecuteError(returncode, stdout, stderr, "-test")
+    except TypeError:
+        error = ExifToolExecuteError(returncode)
+
     error.returncode = returncode
     error.stdout = stdout
     error.stderr = stderr


### PR DESCRIPTION
🎯 **What:** The testing gap in `run_exiftool` within `src/importrr/exifhelper.py` (lines 127-143) is addressed. This block handles `ExifToolExecuteError` and has specific logic for `stdout`, `stderr`, `returncode`, and an `on_error` flag.
📊 **Coverage:** The new parametrized test `test_run_exiftool_error_handling` uses pytest's `@pytest.mark.parametrize` to inject mocked `ExifToolExecuteError` exceptions with varying attribute combinations. It thoroughly covers scenarios such as non-zero exit codes that are logged as warnings, specific "0 image files read" patterns, and differing behavior based on the `on_error` parameter.
✨ **Result:** Test coverage in `exifhelper.py` has been significantly improved, ensuring that error handling logic is verified to prevent regressions and allowing developers to make changes more confidently.

---
*PR created automatically by Jules for task [2602882509507400720](https://jules.google.com/task/2602882509507400720) started by @curfew-marathon*