### PR TITLE
🔒 Fix insecure configuration file loading

### DIFF
--- a/src/importrr/config.py
+++ b/src/importrr/config.py
@@ -2,7 +2,15 @@ import logging
 import os.path
 from configparser import ConfigParser
 
-CANDIDATES = ["config.ini", "/config/config.ini"]
+# Get the absolute path of the project root
+# __file__ is src/importrr/config.py, so we go up two levels to reach the root
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+# Absolute path candidates for the configuration file
+CANDIDATES = [
+    os.path.join(PROJECT_ROOT, "config.ini"),
+    "/config/config.ini",
+]
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
### 🎯 What: The vulnerability fixed
The application was loading `config.ini` using a relative path, which meant it would check the current working directory. If a user ran `importrr` from an untrusted directory containing a malicious `config.ini`, the application would load that configuration.

### ⚠️ Risk: The potential impact if left unfixed
An attacker could gain control over application settings, such as `album_dir`, `archive_dir`, and `import_dir`. This could lead to:
- Data exfiltration (by pointing `archive_dir` to an attacker-controlled path).
- Data loss or corruption (by pointing `album_dir` to sensitive system directories).
- Unauthorized processing of files (by pointing `import_dir` to sensitive directories).

### 🛡️ Solution: How the fix addresses the vulnerability
The `CANDIDATES` list in `src/importrr/config.py` was updated to use absolute paths. Specifically:
- `config.ini` is now looked up using an absolute path relative to the project root (where the application is installed).
- `/config/config.ini` remains an absolute path.
- The insecure relative lookup from the current working directory is removed.

Verification:
- A reproduction script confirmed the vulnerability before the fix.
- The same script confirmed the vulnerability was eliminated after the fix.
- All existing tests passed.
- Ruff formatting and linting were applied.

---
*PR created automatically by Jules for task [13972307212278343518](https://jules.google.com/task/13972307212278343518) started by @curfew-marathon*