### PR TITLE
🧪 [testing improvement] Add tests for transcode.transcode

### DIFF
--- a/tests/mocks/ffmpy/__init__.py
+++ b/tests/mocks/ffmpy/__init__.py
@@ -13,7 +13,7 @@ class FFmpeg:
 
 
 class FFRuntimeError(Exception):
-    def __init__(self, cmd, exit_code, stdout=None, stderr=None):
+    def __init__(self, cmd, exit_code, stdout, stderr):
         self.cmd = cmd
         self.exit_code = exit_code
         self.stdout = stdout

--- a/tests/mocks/ffmpy/__init__.py
+++ b/tests/mocks/ffmpy/__init__.py
@@ -1,9 +1,24 @@
-class FFmpy:
-    pass
+class FFmpeg:
+    def __init__(
+        self, inputs=None, outputs=None, global_options=None, executable="ffmpeg"
+    ):
+        self.inputs = inputs
+        self.outputs = outputs
+        self.global_options = global_options
+        self.executable = executable
+        self.cmd = "ffmpeg mock command"
+
+    def run(self, input_data=None, stdout=None, stderr=None):
+        pass
 
 
 class FFRuntimeError(Exception):
-    pass
+    def __init__(self, cmd, exit_code, stdout=None, stderr=None):
+        self.cmd = cmd
+        self.exit_code = exit_code
+        self.stdout = stdout
+        self.stderr = stderr
+        super().__init__(f"Command '{cmd}' terminated with exit code {exit_code}")
 
 
 class FFExecutableNotFoundError(Exception):

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -130,7 +130,7 @@ def test_transcode_failure_no_output_file(mock_ffmpeg_class, mock_remove, mock_e
     mock_ffmpeg_class.return_value = mock_ffmpeg_instance
 
     # Setup FFRuntimeError
-    error = FFRuntimeError(cmd="ffmpeg", exit_code=1)
+    error = FFRuntimeError(cmd="ffmpeg", exit_code=1, stdout=None, stderr=None)
     mock_ffmpeg_instance.run.side_effect = error
 
     mock_exists.return_value = False

--- a/tests/test_transcode.py
+++ b/tests/test_transcode.py
@@ -1,7 +1,10 @@
 import os
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
-from src.importrr.transcode import convert
+import pytest
+from ffmpy import FFRuntimeError
+
+from src.importrr.transcode import FFMPEG_PARAMS, convert, transcode
 
 
 @patch("src.importrr.transcode.transcode")
@@ -77,3 +80,66 @@ def test_convert_exception(mock_transcode, mock_exists):
         os.path.join(root_dir, "test_video.mov"),
         os.path.join(root_dir, "test_video.mp4"),
     )
+
+
+@patch("src.importrr.transcode.ffmpy.FFmpeg")
+def test_transcode_success(mock_ffmpeg_class):
+    mock_ffmpeg_instance = MagicMock()
+    mock_ffmpeg_class.return_value = mock_ffmpeg_instance
+
+    input_file = "input.mov"
+    output_file = "output.mp4"
+
+    transcode(input_file, output_file)
+
+    mock_ffmpeg_class.assert_called_once_with(
+        inputs={input_file: "-y"}, outputs={output_file: FFMPEG_PARAMS}
+    )
+    mock_ffmpeg_instance.run.assert_called_once()
+
+
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.os.remove")
+@patch("src.importrr.transcode.ffmpy.FFmpeg")
+def test_transcode_failure(mock_ffmpeg_class, mock_remove, mock_exists):
+    mock_ffmpeg_instance = MagicMock()
+    mock_ffmpeg_class.return_value = mock_ffmpeg_instance
+
+    # Setup FFRuntimeError
+    error = FFRuntimeError(cmd="ffmpeg", exit_code=1, stdout="out", stderr="err")
+    mock_ffmpeg_instance.run.side_effect = error
+
+    mock_exists.return_value = True
+
+    input_file = "input.mov"
+    output_file = "output.mp4"
+
+    with pytest.raises(FFRuntimeError) as excinfo:
+        transcode(input_file, output_file)
+
+    assert excinfo.value.exit_code == 1
+    mock_exists.assert_called_once_with(output_file)
+    mock_remove.assert_called_once_with(output_file)
+
+
+@patch("src.importrr.transcode.os.path.exists")
+@patch("src.importrr.transcode.os.remove")
+@patch("src.importrr.transcode.ffmpy.FFmpeg")
+def test_transcode_failure_no_output_file(mock_ffmpeg_class, mock_remove, mock_exists):
+    mock_ffmpeg_instance = MagicMock()
+    mock_ffmpeg_class.return_value = mock_ffmpeg_instance
+
+    # Setup FFRuntimeError
+    error = FFRuntimeError(cmd="ffmpeg", exit_code=1)
+    mock_ffmpeg_instance.run.side_effect = error
+
+    mock_exists.return_value = False
+
+    input_file = "input.mov"
+    output_file = "output.mp4"
+
+    with pytest.raises(FFRuntimeError):
+        transcode(input_file, output_file)
+
+    mock_exists.assert_called_once_with(output_file)
+    mock_remove.assert_not_called()


### PR DESCRIPTION
### 🎯 What
The testing gap for the `transcode.transcode` function has been addressed.

### 📊 Coverage
The following scenarios are now tested:
- **Successful Transcoding:** Verifies that `ffmpy.FFmpeg` is correctly initialized with the expected input/output parameters and that its `run()` method is called.
- **Transcoding Failure (with cleanup):** Verifies that when FFmpeg fails (raises `FFRuntimeError`), the function catches the exception, checks for the existence of the partial output file, removes it, and re-raises the exception.
- **Transcoding Failure (no output file):** Verifies that if FFmpeg fails before creating an output file, the function handles it gracefully without attempting to remove a non-existent file.

### ✨ Result
Improved reliability of the transcoding process and increased overall test coverage for the `importrr` package. The `ffmpy` mock was also enhanced to support more realistic test scenarios.

---
*PR created automatically by Jules for task [2294831202125679900](https://jules.google.com/task/2294831202125679900) started by @curfew-marathon*