### PR TITLE
🧹 Remove unused get_archive method in Config

### DIFF
--- a/src/importrr/config.py
+++ b/src/importrr/config.py
@@ -83,9 +83,6 @@ class Config:
     def get_album(self):
         return self.album_root
 
-    def get_archive(self):
-        return self.archive_root
-
     def get_data(self):
         return self.data
 

--- a/tests/test_config_methods.py
+++ b/tests/test_config_methods.py
@@ -19,10 +19,6 @@ def test_get_album(dummy_config):
     assert dummy_config.get_album() == "/album"
 
 
-def test_get_archive(dummy_config):
-    assert dummy_config.get_archive() == "/archive"
-
-
 def test_get_data(dummy_config):
     assert len(dummy_config.get_data()) == 3
 


### PR DESCRIPTION
🎯 **What:** Removed the unused `get_archive` method from the `Config` class and its associated unit test.
💡 **Why:** This improves maintainability by removing dead code and reducing the API surface area of the `Config` class.
✅ **Verification:**
- Ran `pytest` to ensure all remaining tests pass.
- Ran `ruff` for linting and formatting.
- Confirmed the method is not used elsewhere in the codebase via `grep`.
✨ **Result:** A cleaner and more maintainable `Config` class.

---
*PR created automatically by Jules for task [17407017964272052285](https://jules.google.com/task/17407017964272052285) started by @curfew-marathon*