### PR TITLE
🧪 test: Add missing test for empty import_dir error in Config

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, MagicMock
 from src.importrr.config import Config
 
 
@@ -13,5 +13,27 @@ class TestConfig(unittest.TestCase):
     def test_missing_global_section(self, mock_sections, mock_exists):
         with self.assertRaisesRegex(
             ValueError, "Missing required 'global' section in configuration"
+        ):
+            Config()
+
+    @patch("src.importrr.config.os.path.exists", return_value=True)
+    @patch("src.importrr.config.ConfigParser")
+    def test_empty_import_dir(self, mock_config_parser_class, mock_exists):
+        mock_parser = MagicMock()
+        mock_config_parser_class.return_value = mock_parser
+
+        mock_parser.sections.return_value = ["global", "camera"]
+
+        def getitem_side_effect(key):
+            if key == "global":
+                return {"album_dir": "/album", "archive_dir": "/archive"}
+            elif key == "camera":
+                return {"import_dir": "   ,  "}
+            raise KeyError(key)
+
+        mock_parser.__getitem__.side_effect = getitem_side_effect
+
+        with self.assertRaisesRegex(
+            ValueError, "Empty or invalid 'import_dir' field in section 'camera'"
         ):
             Config()


### PR DESCRIPTION
🎯 **What:** Added missing unit test coverage for the error condition in `Config` when the parsed `import_dir` is empty or only consists of whitespace strings. This resolves an uncovered `ValueError` branch in `src/importrr/config.py`.
📊 **Coverage:** The test covers the scenario where a valid global section exists, but another section provides an `import_dir` value that is evaluated as empty or whitespace (e.g. `"  ,  "`), which leads to a `ValueError`.
✨ **Result:** Increased test coverage in `src/importrr/config.py`, ensuring validation logic surrounding `import_dir` works as intended and preventing future regressions.

---
*PR created automatically by Jules for task [17592674089808277973](https://jules.google.com/task/17592674089808277973) started by @curfew-marathon*