### PR TITLE
Fix adjust_screenshots: restore 3-call priority chain broken by PR #20

### DIFF
--- a/src/importrr/exifhelper.py
+++ b/src/importrr/exifhelper.py
@@ -66,14 +66,26 @@ def adjust_screenshots(import_dir, root_dir):
     ]
 
     # if there is any date in the metadata then add it in
+    # Three sequential calls enforce priority: PNG:CreateDate > XMP:DateCreated > FileModifyDate.
+    # Each call re-checks "not $datetimeoriginal" so later calls only run if earlier ones found nothing.
+    params = [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<PNG:CreateDate",
+        "-XMP:DateCreated<PNG:CreateDate",
+    ] + common_params
+    run_exiftool(root_dir, params)
+
+    params = [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<XMP:DateCreated",
+    ] + common_params
+    run_exiftool(root_dir, params)
+
+    # for everything that's left just use the file modify date
     params = [
         "-overwrite_original",
         "-EXIF:DateTimeOriginal<FileModifyDate",
         "-XMP:DateCreated<FileModifyDate",
-        "-EXIF:DateTimeOriginal<XMP:DateCreated",
-        "-XMP:DateCreated<XMP:DateCreated",
-        "-EXIF:DateTimeOriginal<PNG:CreateDate",
-        "-XMP:DateCreated<PNG:CreateDate",
     ] + common_params
     run_exiftool(root_dir, params)
 

--- a/src/importrr/exifhelper.py
+++ b/src/importrr/exifhelper.py
@@ -150,7 +150,7 @@ def run_exiftool(root_dir, params, on_error=True):
         if 1 == e.returncode:
             if (on_error and " 0 image files read" not in e.stdout) or not on_error:
                 logger.error(f"ExifTool failed with return code {e.returncode}")
-                raise e
+                raise
         else:
             logger.warning(
                 f"ExifTool returned non-zero exit code {e.returncode} but continuing"

--- a/src/importrr/sort.py
+++ b/src/importrr/sort.py
@@ -136,9 +136,9 @@ def last_accessed(file):
 class Sort:
     def __init__(self, root_dir, archive_dir=None):
         if not os.path.isdir(root_dir):
-            raise IOError("Directory doesn't exist " + root_dir)
+            raise OSError("Directory doesn't exist " + root_dir)
         if archive_dir is not None and not os.path.isdir(archive_dir):
-            raise IOError("Directory doesn't exist " + archive_dir)
+            raise OSError("Directory doesn't exist " + archive_dir)
         self.root_dir = root_dir
         self.archive_dir = archive_dir
 
@@ -146,7 +146,7 @@ class Sort:
         logger.info(f"Starting processing for import directory: {import_dir}")
         start = time.time()
         time_cutoff = start - 60 * TIME_CUTOFF
-        prefix = datetime.fromtimestamp(time_cutoff).strftime("%Y%m%d%H%M%S")
+        prefix = datetime.fromtimestamp(time_cutoff).strftime("%Y%m%d%H%M%S")  # noqa: DTZ006
 
         abs_root_dir = os.path.abspath(self.root_dir)
         abs_import_dir = os.path.abspath(os.path.join(abs_root_dir, import_dir))

--- a/src/importrr/transcode.py
+++ b/src/importrr/transcode.py
@@ -35,7 +35,7 @@ def convert(root_dir, source_file):
 
         exifhelper.copy_tags(root_dir, input_file, output_file)
         return result
-    except Exception as e:
+    except Exception as e:  # noqa: BLE001
         logger.error(f"Failed to convert {source_file}: {e}")
         return None  # Return None to skip file if conversion fails
 
@@ -59,4 +59,4 @@ def transcode(input_file, output_file):
         if os.path.exists(output_file):
             os.remove(output_file)
             logger.debug(f"Removed failed output file: {output_file}")
-        raise e
+        raise

--- a/src/launch.py
+++ b/src/launch.py
@@ -35,7 +35,7 @@ def main_process():
                 sort = Sort(d.get("album"), d.get("archive"))
                 for import_dir in d.get("import"):
                     sort.launch(import_dir)
-            except Exception as e:
+            except Exception as e:  # noqa: BLE001
                 logger.error(f"Failed to process section {i}: {e}")
                 logger.debug(f"Section details: {d}")
                 # Continue with next section instead of crashing
@@ -67,7 +67,7 @@ class ImportrrScheduler:
 
     def run_import_job(self):
         """Wrapper function to run the import process with proper logging"""
-        job_start = datetime.now()
+        job_start = datetime.now()  # noqa: DTZ005
         logger.info("=" * 60)
         logger.info(f"Starting scheduled import job at {job_start}")
         logger.info("=" * 60)
@@ -76,15 +76,15 @@ class ImportrrScheduler:
             # Run the main import process
             main_process()
 
-            job_end = datetime.now()
+            job_end = datetime.now()  # noqa: DTZ005
             duration = job_end - job_start
             logger.info("=" * 60)
             logger.info(f"Import job completed successfully at {job_end}")
             logger.info(f"Total duration: {duration}")
             logger.info("=" * 60)
 
-        except Exception as e:
-            job_end = datetime.now()
+        except Exception as e:  # noqa: BLE001
+            job_end = datetime.now()  # noqa: DTZ005
             duration = job_end - job_start
             logger.error("=" * 60)
             logger.error(f"Import job failed at {job_end}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,6 @@
 import unittest
 from unittest.mock import patch
+
 from src.importrr.config import Config
 
 

--- a/tests/test_config_methods.py
+++ b/tests/test_config_methods.py
@@ -1,4 +1,5 @@
 import pytest
+
 from src.importrr.config import Config
 
 

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -1,4 +1,5 @@
-from unittest.mock import patch
+from unittest.mock import call, patch
+
 import pytest
 
 from src.importrr.exifhelper import adjust_extensions
@@ -104,27 +105,48 @@ def test_adjust_screenshots_params(mock_run_exiftool):
     assert mock_run_exiftool.call_count == 3
 
     common = [
-        "-if", "not $datetimeoriginal",
-        "-ext", "GIF", "-ext", "JPG", "-ext", "PNG",
+        "-if",
+        "not $datetimeoriginal",
+        "-ext",
+        "GIF",
+        "-ext",
+        "JPG",
+        "-ext",
+        "PNG",
         import_dir,
     ]
 
-    mock_run_exiftool.assert_any_call(root_dir, [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<PNG:CreateDate",
-        "-XMP:DateCreated<PNG:CreateDate",
-    ] + common)
-
-    mock_run_exiftool.assert_any_call(root_dir, [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<XMP:DateCreated",
-    ] + common)
-
-    mock_run_exiftool.assert_any_call(root_dir, [
-        "-overwrite_original",
-        "-EXIF:DateTimeOriginal<FileModifyDate",
-        "-XMP:DateCreated<FileModifyDate",
-    ] + common)
+    mock_run_exiftool.assert_has_calls(
+        [
+            call(
+                root_dir,
+                [
+                    "-overwrite_original",
+                    "-EXIF:DateTimeOriginal<PNG:CreateDate",
+                    "-XMP:DateCreated<PNG:CreateDate",
+                ]
+                + common,
+            ),
+            call(
+                root_dir,
+                [
+                    "-overwrite_original",
+                    "-EXIF:DateTimeOriginal<XMP:DateCreated",
+                ]
+                + common,
+            ),
+            call(
+                root_dir,
+                [
+                    "-overwrite_original",
+                    "-EXIF:DateTimeOriginal<FileModifyDate",
+                    "-XMP:DateCreated<FileModifyDate",
+                ]
+                + common,
+            ),
+        ],
+        any_order=False,
+    )
 
 
 @patch("src.importrr.exifhelper.os.chdir")
@@ -147,8 +169,9 @@ def test_run_exiftool_error_handling(
     on_error,
     should_raise,
 ):
-    from src.importrr.exifhelper import run_exiftool
     from exiftool.exceptions import ExifToolExecuteError
+
+    from src.importrr.exifhelper import run_exiftool
 
     # To support both the local mock ExifToolExecuteError which takes any args
     # and the real pyexiftool which expects (status, cmd_stdout, cmd_stderr, params),

--- a/tests/test_exifhelper.py
+++ b/tests/test_exifhelper.py
@@ -101,29 +101,30 @@ def test_adjust_screenshots_params(mock_run_exiftool):
 
     adjust_screenshots(import_dir, root_dir)
 
-    assert mock_run_exiftool.call_count == 1
+    assert mock_run_exiftool.call_count == 3
 
-    mock_run_exiftool.assert_called_once_with(
-        root_dir,
-        [
-            "-overwrite_original",
-            "-EXIF:DateTimeOriginal<FileModifyDate",
-            "-XMP:DateCreated<FileModifyDate",
-            "-EXIF:DateTimeOriginal<XMP:DateCreated",
-            "-XMP:DateCreated<XMP:DateCreated",
-            "-EXIF:DateTimeOriginal<PNG:CreateDate",
-            "-XMP:DateCreated<PNG:CreateDate",
-            "-if",
-            "not $datetimeoriginal",
-            "-ext",
-            "GIF",
-            "-ext",
-            "JPG",
-            "-ext",
-            "PNG",
-            import_dir,
-        ],
-    )
+    common = [
+        "-if", "not $datetimeoriginal",
+        "-ext", "GIF", "-ext", "JPG", "-ext", "PNG",
+        import_dir,
+    ]
+
+    mock_run_exiftool.assert_any_call(root_dir, [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<PNG:CreateDate",
+        "-XMP:DateCreated<PNG:CreateDate",
+    ] + common)
+
+    mock_run_exiftool.assert_any_call(root_dir, [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<XMP:DateCreated",
+    ] + common)
+
+    mock_run_exiftool.assert_any_call(root_dir, [
+        "-overwrite_original",
+        "-EXIF:DateTimeOriginal<FileModifyDate",
+        "-XMP:DateCreated<FileModifyDate",
+    ] + common)
 
 
 @patch("src.importrr.exifhelper.os.chdir")


### PR DESCRIPTION
## Problem

PR #20 collapsed three sequential ExifTool calls in `adjust_screenshots` into a single call, introducing two bugs:

**1. XMP:DateCreated source corrupted before it is read**

In the single-call version, `-XMP:DateCreated<FileModifyDate` runs before `-EXIF:DateTimeOriginal<XMP:DateCreated`. ExifTool processes assignments left to right within a single invocation, so by the time it tries to copy XMP:DateCreated into DateTimeOriginal, XMP:DateCreated has already been overwritten with FileModifyDate. For any file that has XMP:DateCreated metadata but no PNG:CreateDate, this produces the wrong date.

**2. Spurious self-assignment not in the original**

PR #20 introduced `-XMP:DateCreated<XMP:DateCreated`, which was not present before. Copying a tag to itself after it has already been overwritten by FileModifyDate is at best a no-op and at worst misleading.

## Root cause

The original design relied on three sequential ExifTool invocations, each re-evaluating the `-if "not $datetimeoriginal"` condition. This ensured that once a higher-priority source set the tag, the lower-priority fallbacks were skipped entirely. Collapsing to one call removes that re-evaluation.

## Fix

Restores the 3-call sequential approach with correct priority:

1. `PNG:CreateDate` (highest priority, sets both DateTimeOriginal and XMP:DateCreated)
2. `XMP:DateCreated` (only runs if DateTimeOriginal still empty)
3. `FileModifyDate` (fallback, only runs if DateTimeOriginal still empty)

Updates the test to assert 3 calls with the correct params for each.

## Verification

```
PYTHONPATH=.:src pytest tests/test_exifhelper.py -q
9 passed
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved screenshot date handling with a reliable fallback order.
  * Preserves existing capture dates while filling missing dates from PNG metadata, XMP metadata, or file modification dates.
  * Improved error reporting for sorting and media conversion failures by preserving original error details.

* **Tests**
  * Updated coverage to verify the ordered date fallback behavior and related processing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->